### PR TITLE
식당 API CRUD 완료

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,9 +16,18 @@ repositories {
 }
 
 dependencies {
+
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.projectlombok:lombok:1.18.22'
-    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation group: 'org.mariadb.jdbc', name: 'mariadb-java-client', version: '2.7.0'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	compileOnly 'org.projectlombok:lombok'
+	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+	annotationProcessor 'org.projectlombok:lombok'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/stopwait/restaurant/RestaurRepository.java
+++ b/src/main/java/com/example/stopwait/restaurant/RestaurRepository.java
@@ -1,15 +1,18 @@
 package com.example.stopwait.restaurant;
 
+import org.springframework.data.jpa.repository.JpaRepository;
+
 import java.util.List;
+import java.util.Optional;
 
 public interface RestaurRepository {
 
     int save(Restaurant restaurant);
     List<Restaurant> findAll();
-    Restaurant findById(int restaurantId);
+    Optional<Restaurant> findById(int restaurantId);
 
-    Restaurant update(Restaurant restaurant);
+    int delete(int restaurantId);
 
-    void delete(int restaurantId);
+    Optional<Restaurant> findByName(String name);
 
 }

--- a/src/main/java/com/example/stopwait/restaurant/Restaurant.java
+++ b/src/main/java/com/example/stopwait/restaurant/Restaurant.java
@@ -1,63 +1,31 @@
 package com.example.stopwait.restaurant;
 
+import lombok.Data;
+import lombok.NonNull;
+import org.hibernate.annotations.NotFound;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
+import java.util.Optional;
+
+
+@Entity
+@Data
 public class Restaurant {
 
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     int id;
+
+    @NotBlank
     String name;
     String content;
 
-    Category category;
+    //Category category;
 
     String rating;
 
     String review;
 
-    public int getId() {
-        return id;
-    }
 
-    public String getName() {
-        return name;
-    }
 
-    public String getContent() {
-        return content;
-    }
-
-    public Restaurant setName(String name) {
-        this.name = name;
-        return this;
-    }
-
-    public Restaurant setContent(String content) {
-        this.content = content;
-        return this;
-    }
-
-    public Restaurant setCategory(Category category) {
-        this.category = category;
-        return this;
-    }
-
-    public Restaurant setRating(String rating) {
-        this.rating = rating;
-        return this;
-    }
-
-    public Restaurant setReview(String review) {
-        this.review = review;
-        return this;
-    }
-
-    public Category getCategory() {
-        return category;
-    }
-
-    public String getRating() {
-        return rating;
-    }
-
-    public String getReview() {
-        return review;
-    }
 }

--- a/src/main/java/com/example/stopwait/restaurant/RestaurantController.java
+++ b/src/main/java/com/example/stopwait/restaurant/RestaurantController.java
@@ -2,62 +2,87 @@ package com.example.stopwait.restaurant;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
-import java.util.HashMap;
+import java.net.URI;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.Optional;
 
-@Controller
+@RestController
 @RequestMapping("/restaurants")
-@ResponseBody
 public class RestaurantController {
 
     private final RestaurantService restaurantService;
 
     @Autowired
     public RestaurantController(RestaurantService restaurantService) {
+
         this.restaurantService = restaurantService;
     }
 
+
     @PostMapping
-    public int createRest(@RequestBody Restaurant restaurant) {
-        return restaurantService.createRest(restaurant);
+    public ResponseEntity createRest(@RequestBody Restaurant restaurant) {
+        int newRest = restaurantService.createRest(restaurant);
+
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .path("/{restuarantId}")
+                .buildAndExpand(newRest)
+                .toUri();
+
+        return ResponseEntity.created(location)
+                .body(newRest)
+                ;
     }
 
     @GetMapping
-    public List<Restaurant> getAllRest() {
-        return restaurantService.getAllRest();
+    public ResponseEntity<List<Restaurant>> getAllRest() {
+        List<Restaurant> allRest = restaurantService.getAllRest();
+
+        return ResponseEntity.ok()
+                .body(allRest);
     }
 
     @GetMapping("/{restaurantId}")
     public ResponseEntity<Restaurant> getRest(@PathVariable int restaurantId) {
-        Restaurant rest = restaurantService.getRest(restaurantId);
+        Optional<Restaurant> rest = restaurantService.getRest(restaurantId);
 
         HttpHeaders headers = new HttpHeaders();
 
-        if (rest == null) {
+        if (!rest.isPresent()) {
             return ResponseEntity.badRequest()
-                    .body(rest);
+                    .body(new Restaurant());
         }
 
         return ResponseEntity.ok()
-                .body(rest);
+                .body(rest.get());
+
     }
 
 
-    @PatchMapping
-    public Restaurant updateRest(@RequestBody Restaurant restaurant) {
-        return restaurantService.updateRest(restaurant);
+    @PatchMapping("{restaurantId}")
+    public ResponseEntity<Restaurant> updateRest(int restaurantId, @RequestBody UpdateRestDto updateRestDto) {
+        Restaurant updateRest = restaurantService.updateRest(restaurantId, updateRestDto);
+
+        return ResponseEntity.ok()
+                .body(updateRest);
     }
 
     @DeleteMapping("/{restaurantId}")
-    public void deleteRest(@PathVariable int restaurantId) {
+    public ResponseEntity deleteRest(@PathVariable int restaurantId) {
+
         restaurantService.deleteRest(restaurantId);
+
+        return ResponseEntity.noContent().build();
+    }
+
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<String> handleException(IllegalStateException e) {
+        return ResponseEntity.badRequest()
+                .body(e.getMessage());
     }
 }

--- a/src/main/java/com/example/stopwait/restaurant/RestaurantJpaRepository.java
+++ b/src/main/java/com/example/stopwait/restaurant/RestaurantJpaRepository.java
@@ -1,0 +1,52 @@
+package com.example.stopwait.restaurant;
+
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.Query;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@Transactional
+public class RestaurantJpaRepository implements RestaurRepository{
+
+    private final EntityManager em;
+
+    public RestaurantJpaRepository(EntityManager em) {
+        this.em = em;
+    }
+
+    @Override
+    public int save(Restaurant restaurant) {
+        em.persist(restaurant);
+        return restaurant.getId();
+    }
+
+    @Override
+    public List<Restaurant> findAll() {
+        return em.createQuery("select r from Restaurant r", Restaurant.class)
+                .getResultList();
+    }
+
+    @Override
+    public Optional<Restaurant> findById(int restaurantId) {
+        return Optional.ofNullable(em.find(Restaurant.class, restaurantId));
+    }
+
+    @Override
+    public int delete(int id) {
+        return em.createQuery("delete from  Restaurant r where r.id = :id")
+                .setParameter("id", id).executeUpdate();
+    }
+
+    @Override
+    public Optional<Restaurant> findByName(String name) {
+         return em.createQuery("select r from Restaurant r where r.name = :name", Restaurant.class)
+                .setParameter("name", name)
+                .getResultList()
+                .stream()
+                .findAny();
+    }
+}

--- a/src/main/java/com/example/stopwait/restaurant/RestaurantMapRepository.java
+++ b/src/main/java/com/example/stopwait/restaurant/RestaurantMapRepository.java
@@ -2,12 +2,8 @@ package com.example.stopwait.restaurant;
 
 import org.springframework.stereotype.Repository;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
-@Repository
 public class RestaurantMapRepository implements RestaurRepository{
 
     private static Map<Integer, Restaurant> db = new HashMap<>();
@@ -24,16 +20,15 @@ public class RestaurantMapRepository implements RestaurRepository{
     }
 
     @Override
-    public Restaurant findById(int restaurantId) {
-        return db.get(restaurantId);
+    public Optional<Restaurant> findById(int restaurantId) {
+        return Optional.ofNullable(db.get(restaurantId));
     }
 
-    @Override
     public Restaurant update(Restaurant restaurant) {
         Restaurant updateRest = db.get(restaurant.getId());
         updateRest.setName(restaurant.getName());
         updateRest.setContent(restaurant.getContent());
-        updateRest.setCategory(restaurant.getCategory());
+        //updateRest.setCategory(restaurant.getCategory());
         updateRest.setRating(restaurant.getRating());
         updateRest.setReview(restaurant.getReview());
 
@@ -43,7 +38,13 @@ public class RestaurantMapRepository implements RestaurRepository{
     }
 
     @Override
-    public void delete(int restaurantId) {
+    public int delete(int restaurantId) {
         db.remove(restaurantId);
+        return db.size();
+    }
+
+    @Override
+    public Optional<Restaurant> findByName(String name) {
+        return Optional.empty();
     }
 }

--- a/src/main/java/com/example/stopwait/restaurant/RestaurantService.java
+++ b/src/main/java/com/example/stopwait/restaurant/RestaurantService.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class RestaurantService {
@@ -16,6 +17,7 @@ public class RestaurantService {
     }
 
     public int createRest(Restaurant restaurant) {
+        vaildateDulplicateRest(restaurant);
         return restaurantRepository.save(restaurant);
     }
 
@@ -23,15 +25,33 @@ public class RestaurantService {
         return restaurantRepository.findAll();
     }
 
-    public Restaurant getRest(int restaurantId) {
+    public Optional<Restaurant> getRest(int restaurantId) {
         return restaurantRepository.findById(restaurantId);
     }
 
-    public Restaurant updateRest(Restaurant restaurant) {
-        return restaurantRepository.update(restaurant);
+    public Restaurant updateRest(int restaurantId, UpdateRestDto updateRestDto) {
+
+        Restaurant updateRest = restaurantRepository.findById(restaurantId).get();
+        updateRest.setName(updateRestDto.getName());
+        updateRest.setRating(updateRestDto.getRating());
+        updateRest.setContent(updateRestDto.getContent());
+        updateRest.setReview(updateRestDto.getReview());
+
+        vaildateDulplicateRest(updateRest);
+
+        restaurantRepository.save(updateRest);
+
+        return updateRest;
     }
 
     public void deleteRest(int restaurantId) {
         restaurantRepository.delete(restaurantId);
+    }
+
+    public void vaildateDulplicateRest(Restaurant restaurant) {
+        restaurantRepository.findByName(restaurant.getName())
+                        .ifPresent(rest -> {
+                            throw new IllegalStateException("이미 존재하는 식당명입니다.");
+                        });
     }
 }

--- a/src/main/java/com/example/stopwait/restaurant/UpdateRestDto.java
+++ b/src/main/java/com/example/stopwait/restaurant/UpdateRestDto.java
@@ -1,0 +1,14 @@
+package com.example.stopwait.restaurant;
+
+import lombok.Data;
+
+@Data
+public class UpdateRestDto {
+
+    String name;
+
+    String content;
+
+    String review;
+    String rating;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,8 @@
 
+spring.datasource.url=jdbc:mariadb://localhost:3306/StopWait
+spring.datasource.driver-class-name=org.mariadb.jdbc.Driver
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MariaDBDialect
+#spring.datasource.driver-class-name=com.mysql.jdbc.Driver
+spring.datasource.username=root
+spring.datasource.password=root
+


### PR DESCRIPTION
식당 API CRUD 구현

주요구현내용
- 식당 CRUD 포스트맨으로 테스트완료 (Http Status도 확인)
- mariaDB 연동 : application.properties에 설정
- 식당수정을 위해 dto 추가 : UpdateRestDto
- JPA 추가 : RestaurantJpaRepository
- 식당이름 중복체크로직 추가  : RestaurantService의 vaildateDulplicateRest 메소드
- @ExceptionHandler를 이용한 예외처리 메세지 구현 : RestaurantController 의 handleException 메소드

이슈
1. dto의 필드 범위 설정 -> set을 하면안되는(pk값)을 제외한 모든 필드로 구성함

다음계획
- spring data jpa로 변경