### PR TITLE
카테고리 및 예약 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation group: 'org.mariadb.jdbc', name: 'mariadb-java-client', version: '2.7.0'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+    testImplementation 'org.projectlombok:lombok:1.18.28'
 
-	compileOnly 'org.projectlombok:lombok'
+    compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/example/stopwait/Reservation/Reservation.java
+++ b/src/main/java/com/example/stopwait/Reservation/Reservation.java
@@ -1,0 +1,43 @@
+package com.example.stopwait.Reservation;
+
+import com.example.stopwait.restaurant.Restaurant;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Entity
+@Getter @Setter
+public class Reservation {
+
+    @Id @GeneratedValue
+    private int id;
+
+    @ManyToOne
+    @JoinColumn(name = "restaurant_id")
+    private Restaurant restaurant;
+
+    @Column(nullable = false)
+    private LocalDate ReservationDt;
+
+    @Column(nullable = false)
+    private LocalTime ReservationTime;
+
+    private int deposit;
+
+    @Enumerated(EnumType.STRING)
+    private ReservationStatus reservationStatus;
+
+    private LocalDate modifyDt;
+
+    public void changeReservationCheck() {
+        if (LocalDate.now().isEqual(this.ReservationDt)
+                && LocalTime.now().minusHours(1).isAfter(this.ReservationTime)) {
+            throw new IllegalStateException("예약 한시간 전에는 예약을 변경 하거나 취소 할 수 없습니다");
+        }
+
+    }
+}

--- a/src/main/java/com/example/stopwait/Reservation/ReservationController.java
+++ b/src/main/java/com/example/stopwait/Reservation/ReservationController.java
@@ -1,0 +1,31 @@
+package com.example.stopwait.Reservation;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/reservations")
+public class ReservationController {
+
+    private final ReservationService reservationService;
+
+    @Autowired
+
+    public ReservationController(ReservationService reservationService) {
+        this.reservationService = reservationService;
+    }
+
+    @PostMapping
+    public void cerateReservstion(@RequestBody Reservation reservation) {
+        reservationService.reserve(reservation);
+    }
+
+    @GetMapping("/{reservation_id}")
+    public Reservation getReservation(@PathVariable int restaurant_id) {
+        return reservationService.findOne(restaurant_id);
+    }
+
+}

--- a/src/main/java/com/example/stopwait/Reservation/ReservationRepositoty.java
+++ b/src/main/java/com/example/stopwait/Reservation/ReservationRepositoty.java
@@ -1,0 +1,24 @@
+package com.example.stopwait.Reservation;
+
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.util.Optional;
+
+@Repository
+public class ReservationRepositoty {
+
+    private final EntityManager em;
+
+    public ReservationRepositoty(EntityManager em) {
+        this.em = em;
+    }
+
+    public void save(Reservation reservation) {
+        em.persist(reservation);
+    }
+
+    public Reservation findById(int reservationid) {
+        return em.find(Reservation.class, reservationid);
+    }
+}

--- a/src/main/java/com/example/stopwait/Reservation/ReservationService.java
+++ b/src/main/java/com/example/stopwait/Reservation/ReservationService.java
@@ -1,0 +1,48 @@
+package com.example.stopwait.Reservation;
+
+import com.example.stopwait.restaurant.Restaurant;
+import com.example.stopwait.restaurant.RestaurantJpaRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Service
+public class ReservationService {
+
+    private final ReservationRepositoty reservationRepositoty;
+    private final RestaurantJpaRepository restaurantJpaRepository;
+
+    public ReservationService(ReservationRepositoty reservationRepositoty, RestaurantJpaRepository restaurantJpaRepository) {
+        this.reservationRepositoty = reservationRepositoty;
+        this.restaurantJpaRepository = restaurantJpaRepository;
+    }
+
+    @Autowired
+
+
+    public void reserve(Reservation reservation) {
+        Restaurant restaurant = restaurantJpaRepository.findById(reservation.getRestaurant().getId()).get();
+        reservation.setRestaurant(restaurant);
+        reservation.setReservationStatus(ReservationStatus.RESERVATION);
+        reservationRepositoty.save(reservation);
+    }
+
+    public Reservation findOne(int restauratnId) {
+        return reservationRepositoty.findById(restauratnId);
+    }
+
+    public void cancel(int reservationId) {
+
+        Reservation CancelReserve = reservationRepositoty.findById(reservationId);
+        CancelReserve.changeReservationCheck(); //예약 validation
+        CancelReserve.setReservationStatus(ReservationStatus.CANCEL);
+    }
+
+    public void change(@RequestBody updateReserveFrom updateReserveFrom, int reservationId) {
+        Reservation modifyReserve = reservationRepositoty.findById(reservationId);
+        modifyReserve.changeReservationCheck(); //예약 validation
+
+        modifyReserve.setReservationDt(updateReserveFrom.getReservationDt());
+        modifyReserve.setReservationTime(updateReserveFrom.getReservationTime());
+    }
+}

--- a/src/main/java/com/example/stopwait/Reservation/ReservationStatus.java
+++ b/src/main/java/com/example/stopwait/Reservation/ReservationStatus.java
@@ -1,0 +1,6 @@
+package com.example.stopwait.Reservation;
+
+
+public enum ReservationStatus {
+    RESERVATION, CANCEL
+}

--- a/src/main/java/com/example/stopwait/Reservation/updateReserveFrom.java
+++ b/src/main/java/com/example/stopwait/Reservation/updateReserveFrom.java
@@ -1,0 +1,14 @@
+package com.example.stopwait.Reservation;
+
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+public class updateReserveFrom {
+
+    private LocalDate ReservationDt;
+
+    private LocalTime ReservationTime;
+}

--- a/src/main/java/com/example/stopwait/category/CategoryController.java
+++ b/src/main/java/com/example/stopwait/category/CategoryController.java
@@ -4,16 +4,18 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.stereotype.Repository;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.net.URI;
+import java.util.List;
 
 @Controller
 @RequiredArgsConstructor
-@RequestMapping("categories")
+@RequestMapping("/categories")
 public class CategoryController {
 
     private final CategoryService categoryService;
@@ -31,4 +33,5 @@ public class CategoryController {
                 .created(uri)
                 .body(newCategory);
     }
+
 }

--- a/src/main/java/com/example/stopwait/restaurant/FormRestaurantDto.java
+++ b/src/main/java/com/example/stopwait/restaurant/FormRestaurantDto.java
@@ -1,0 +1,19 @@
+package com.example.stopwait.restaurant;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+import java.util.Map;
+
+@Setter @Getter
+public class FormRestaurantDto {
+
+    private String name;
+
+    private String content;
+
+    private String rating;
+
+    private List<Map<Integer, String>> categories;
+}

--- a/src/main/java/com/example/stopwait/restaurant/Restaurant.java
+++ b/src/main/java/com/example/stopwait/restaurant/Restaurant.java
@@ -1,5 +1,6 @@
 package com.example.stopwait.restaurant;
 
+import com.example.stopwait.Reservation.Reservation;
 import com.example.stopwait.category.RestaurantCategory;
 import com.example.stopwait.review.Review;
 import lombok.Data;
@@ -12,6 +13,7 @@ import javax.validation.constraints.NotBlank;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 
 @Entity
@@ -23,16 +25,29 @@ public class Restaurant {
     private int id;
 
     @NotBlank(message = "식당명은 필수입니다.")
+    @Column(nullable = false)
     private String name;
 
+    @Lob
     private String content;
 
-    //@OneToMany(mappedBy = "restaurant", cascade = CascadeType.ALL)
-    //private List<RestaurantCategory> restaurantCategories = new ArrayList<>();
+    @OneToMany(mappedBy = "restaurant", cascade = CascadeType.ALL)
+    private List<RestaurantCategory> restaurantCategories = new ArrayList<>();
+
+    @Transient
+    private List<Integer> categories;
+
+    public void addRestaurantCategory(RestaurantCategory restaurantCategory) {
+        restaurantCategory.setRestaurant(this);
+        restaurantCategories.add(restaurantCategory);
+    }
 
     private String rating;
 
     @OneToMany( mappedBy = "restaurant", cascade = CascadeType.ALL)
     private List<Review> reviews = new ArrayList<>();
+
+    @OneToMany(mappedBy = "restaurant")
+    private List<Reservation> reservation = new ArrayList<>();
 
 }

--- a/src/main/java/com/example/stopwait/restaurant/RestaurantController.java
+++ b/src/main/java/com/example/stopwait/restaurant/RestaurantController.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Optional;
 
 @RestController
-@RequestMapping("/ㄱ")
+@RequestMapping("/restaurants")
 @Slf4j
 public class RestaurantController {
 
@@ -43,7 +43,7 @@ public class RestaurantController {
     }
 
     @GetMapping
-    public ResponseEntity<List<Restaurant>> getAllRest() {
+    public ResponseEntity<List<Restaurant>> getAllRestarant() {
         List<Restaurant> allRest = restaurantService.getAllRest();
         log.info("restaurants :{}", allRest.get(0).getName());
         log.info("restaurants :{}", allRest.get(0).getReviews().get(0));
@@ -52,7 +52,7 @@ public class RestaurantController {
     }
 
     @GetMapping("/{restaurantId}")
-    public ResponseEntity<Restaurant> getRest(@PathVariable int restaurantId) {
+    public ResponseEntity<Restaurant> getRestarant(@PathVariable int restaurantId) {
         Optional<Restaurant> rest = restaurantService.getRest(restaurantId);
 
         HttpHeaders headers = new HttpHeaders();

--- a/src/main/java/com/example/stopwait/restaurant/RestaurantJpaRepository.java
+++ b/src/main/java/com/example/stopwait/restaurant/RestaurantJpaRepository.java
@@ -1,5 +1,7 @@
 package com.example.stopwait.restaurant;
 
+import com.example.stopwait.category.Category;
+import com.example.stopwait.category.RestaurantCategory;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
@@ -7,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Repository
@@ -22,6 +25,13 @@ public class RestaurantJpaRepository implements RestaurRepository{
 
     @Override
     public int save(Restaurant restaurant) {
+
+        for (Integer categoryId : restaurant.getCategories()) {
+            Category category = em.find(Category.class, categoryId);
+            RestaurantCategory restaurantCategory = new RestaurantCategory();
+            restaurantCategory.setCategory(category);
+            restaurant.addRestaurantCategory(restaurantCategory);
+        }
         em.persist(restaurant);
         log.debug("repository save : {}" , restaurant.getId());
         return restaurant.getId();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,7 +7,7 @@ spring.datasource.username=root
 spring.datasource.password=root
 
 spring.jpa.show-sql=true
-spring.jpa.hibernate.ddl-auto=none
+spring.jpa.hibernate.ddl-auto=create
 
 spring.jpa.open-in-view=false
 

--- a/src/test/java/com/example/stopwait/StopwaitApplicationTests.java
+++ b/src/test/java/com/example/stopwait/StopwaitApplicationTests.java
@@ -1,13 +1,20 @@
 package com.example.stopwait;
 
+import com.example.stopwait.category.Category;
+import com.example.stopwait.restaurant.Restaurant;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.time.LocalDate;
+
 @SpringBootTest
+@Slf4j
 class StopwaitApplicationTests {
 
 	@Test
-	void contextLoads() {
+	void test() {
+
 	}
 
 }


### PR DESCRIPTION
구현내용

- Category 생성 구현 및 Restaurant 엔티티에 추가
- Reservation 생성, 수정, 취소, 아이디조회 구현

이슈
@OneToMany 의 cascade = CascadeType.ALL 프로세스 이해부족으로 레스토랑을 저장할때 카테고리를 어떻게 저장할지고민
cascade 는 연관관계와 상관이없으며 (제 코드기준)  Restaurant 의 RestaurantCategory list에 add를 하면
 Restaurant엔티티를 persist 할시 RestaurantCategory의 엔티티도 같이 persist를 해준다. 
! 주의 Restaurant. 컬렉션에 넣어주지 않을시 RestaurantCategory이 저장이 되지않는다.

다음계획
- Entity -> DTO 로 변경
- 카테고리 삭제, 수정 기능 추가
- pr 리뷰 수정
- 커스텀 예외 클래스 구현
